### PR TITLE
Adjust WPForms name and email field widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2025-09-16
+### Changed
+- Vergroot de WPForms velden voor naam en e-mail naar volledige breedte voor consistentie met het omschrijvingsveld.
+
 ## [1.0.0] - 2025-09-16
 ### Added
 - Initial release of the RikkerMediaHub Divi child theme with custom styling for WPForms and MailerLite.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.0
+ * Version:          1.1
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).
@@ -51,6 +51,25 @@ div.wpforms-container .wpforms-form .wpforms-field select {
   font-size: 0.95rem !important;
   color: #212121 !important;
   transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+}
+
+/* 5a. Naam- en e-mailvelden op volledige breedte */
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name,
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
+  display: block !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
+  width: 100% !important;
+  max-width: 100% !important;
+  float: none !important;
+  padding-right: 0 !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block + .wpforms-field-row-block {
+  margin-top: 1rem !important;
 }
 div.wpforms-container .wpforms-form .wpforms-field input:focus,
 div.wpforms-container .wpforms-form .wpforms-field textarea:focus,


### PR DESCRIPTION
## Summary
- expand the WPForms name and email fields so they span the full width like the description field
- bump the child theme version to 1.1 and record the update in the changelog

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68c977f09a94832ca6fb5be6125645ff