### PR TITLE
Restore two-column layout for WPForms name fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-09-16
+### Fixed
+- Paste de WPForms naamvelden aan zodat voor- en achternaam naast elkaar staan met elk 50% breedte en hield het e-mailveld op volledige breedte.
+
+## [1.1.0] - 2025-09-16
+### Changed
+- Vergroot de WPForms velden voor naam en e-mail naar volledige breedte voor consistentie met het omschrijvingsveld.
+
 ## [1.0.0] - 2025-09-16
 ### Added
 - Initial release of the RikkerMediaHub Divi child theme with custom styling for WPForms and MailerLite.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.0
+ * Version:          1.2
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).
@@ -51,6 +51,46 @@ div.wpforms-container .wpforms-form .wpforms-field select {
   font-size: 0.95rem !important;
   color: #212121 !important;
   transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+}
+
+/* 5a. Naam- en e-mailvelden */
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name,
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name fieldset {
+  width: 100% !important;
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: 0 !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 1rem !important;
+  margin: 0 !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
+  flex: 1 1 calc(50% - 0.5rem) !important;
+  max-width: calc(50% - 0.5rem) !important;
+  margin: 0 !important;
+  float: none !important;
+  padding-right: 0 !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block input,
+div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email input {
+  width: 100% !important;
+}
+@media (max-width: 640px) {
+  div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
+    gap: 0.75rem !important;
+  }
+  div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
+    flex-basis: 100% !important;
+    max-width: 100% !important;
+  }
 }
 div.wpforms-container .wpforms-form .wpforms-field input:focus,
 div.wpforms-container .wpforms-form .wpforms-field textarea:focus,


### PR DESCRIPTION
## Summary
- place the WPForms first and last name inputs side-by-side at 50% each while keeping the email field full width
- update the 1.2 changelog entry to describe the revised layout

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c977f09a94832ca6fb5be6125645ff