### PR TITLE
Fix WPForms name layout and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2025-09-17
+### Fixed
+- Herstelde de WPForms-naamvelden door een gridindeling te gebruiken zodat voor- en achternaam weer netjes naast elkaar staan op desktop en volledig stapelen op kleine schermen.
+
 ## [1.2.0] - 2025-09-16
 ### Fixed
 - Paste de WPForms naamvelden aan zodat voor- en achternaam naast elkaar staan met elk 50% breedte en hield het e-mailveld op volledige breedte.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.2
+ * Version:          1.3
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).
@@ -67,14 +67,14 @@ div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name fieldset {
   border: 0 !important;
 }
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-  display: flex !important;
-  flex-wrap: wrap !important;
+  display: grid !important;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important;
   gap: 1rem !important;
   margin: 0 !important;
 }
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-  flex: 1 1 calc(50% - 0.5rem) !important;
-  max-width: calc(50% - 0.5rem) !important;
+  width: 100% !important;
+  max-width: 100% !important;
   margin: 0 !important;
   float: none !important;
   padding-right: 0 !important;
@@ -85,10 +85,10 @@ div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email input {
 }
 @media (max-width: 640px) {
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
+    grid-template-columns: 1fr !important;
     gap: 0.75rem !important;
   }
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-    flex-basis: 100% !important;
     max-width: 100% !important;
   }
 }


### PR DESCRIPTION
## Summary
- replace the WPForms name-field flex layout with a responsive CSS grid so first and last name align correctly
- ensure the mobile breakpoint collapses to a single column and keep row blocks full width
- bump the child theme version to 1.3.0 and document the fix in the changelog

## Testing
- not run (WordPress theme)


------
https://chatgpt.com/codex/tasks/task_e_68c9c70633c0832ca2f27787e2419eb1