### PR TITLE
Align name fields and refresh submit button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+# [1.7.0] - 2025-09-19
+### Changed
+- Zorgde ervoor dat de WPForms-velden voor voor- en achternaam naast elkaar staan op grotere schermen en mobiel blijven stapelen.
+- Paste de WPForms verzendknop aan naar de primaire en secundaire huisstijlkleuren met wittekstopmaak.
+
 # [1.6.0] - 2025-09-19
 ### Fixed
 - Vervingen van moderne CSS-features door breed ondersteunde alternatieven zodat de WordPress theme editor geen fouten meer meldt.

--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -134,26 +134,27 @@ div.wpforms-container .wpforms-form .wpforms-field-hint {
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
   display: flex;
-  flex-wrap: wrap;
-  margin: -0.25rem;
+  flex-direction: column;
+  row-gap: 0.75rem;
+  margin: 0;
   padding: 0;
 }
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-  flex: 1 1 220px;
-  min-width: 220px;
+  flex: 1 1 100%;
+  min-width: 0;
   margin: 0;
-  padding: 0.25rem;
+  padding: 0;
 }
 
-@media (max-width: 40em) {
+@media (min-width: 48em) {
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-    flex-direction: column;
+    flex-direction: row;
+    column-gap: 1.5rem;
   }
 
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-    flex-basis: 100%;
-    min-width: 100%;
+    flex-basis: 0;
   }
 }
 
@@ -222,8 +223,8 @@ div.wpforms-container .wpforms-form .wpforms-submit {
   padding: 0.875rem 2.5rem;
   border: 0;
   border-radius: 0.5rem;
-  background-color: var(--et_pb_primary_color, #e53935);
-  color: #fff;
+  background-color: #e53935;
+  color: #ffffff;
   font: inherit;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -241,9 +242,9 @@ div.wpforms-container .wpforms-form .wpforms-submit > *:not(:last-child) {
 div.wpforms-container .wpforms-form .wpforms-submit:hover,
 div.wpforms-container .wpforms-form .wpforms-submit:focus,
 div.wpforms-container .wpforms-form .wpforms-submit:focus-visible {
-  background-color: var(--et_pb_primary_hover_color, #c62828);
-  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.18);
-  outline: 2px solid var(--et_pb_primary_hover_color, #c62828);
+  background-color: #b71c1c;
+  box-shadow: 0 0 0 3px rgba(183, 28, 28, 0.18);
+  outline: 2px solid #b71c1c;
   outline-offset: 2px;
   transform: translateY(-1px);
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.6.0
+ * Version:          1.7.0
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).


### PR DESCRIPTION
## Summary
- keep WPForms voornaam/achternaam inputs side-by-side on wide viewports while stacking them on mobile
- update the WPForms submit button colors to match the primary and secondary red brand tones with white text
- bump the child theme version to 1.7.0 and document the changes in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca6c5d2df4832c97da9e0cca408f36