### PR TITLE
Align WPForms name inputs and update submit button color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# [1.8.0] - 2025-09-19
+### Changed
+- Lijn de WPForms velden voor voor- en achternaam gelijk met het e-mailadres en gebruik #e53935 als standaardknopkleur.
+
 # [1.7.0] - 2025-09-19
 ### Changed
 - Zorgde ervoor dat de WPForms-velden voor voor- en achternaam naast elkaar staan op grotere schermen en mobiel blijven stapelen.

--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -133,15 +133,15 @@ div.wpforms-container .wpforms-form .wpforms-field-hint {
 }
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   row-gap: 0.75rem;
+  column-gap: 0;
   margin: 0;
   padding: 0;
 }
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-  flex: 1 1 100%;
   min-width: 0;
   margin: 0;
   padding: 0;
@@ -149,12 +149,9 @@ div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-f
 
 @media (min-width: 48em) {
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-    flex-direction: row;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     column-gap: 1.5rem;
-  }
-
-  div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-    flex-basis: 0;
+    row-gap: 0;
   }
 }
 
@@ -216,7 +213,8 @@ div.wpforms-container .wpforms-form .wpforms-submit-container > * {
   margin: 0 1rem 1rem 0;
 }
 
-div.wpforms-container .wpforms-form .wpforms-submit {
+div.wpforms-container .wpforms-form .wpforms-submit,
+div.wpforms-container .wpforms-form button[type="submit"] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -241,7 +239,10 @@ div.wpforms-container .wpforms-form .wpforms-submit > *:not(:last-child) {
 
 div.wpforms-container .wpforms-form .wpforms-submit:hover,
 div.wpforms-container .wpforms-form .wpforms-submit:focus,
-div.wpforms-container .wpforms-form .wpforms-submit:focus-visible {
+div.wpforms-container .wpforms-form .wpforms-submit:focus-visible,
+div.wpforms-container .wpforms-form button[type="submit"]:hover,
+div.wpforms-container .wpforms-form button[type="submit"]:focus,
+div.wpforms-container .wpforms-form button[type="submit"]:focus-visible {
   background-color: #b71c1c;
   box-shadow: 0 0 0 3px rgba(183, 28, 28, 0.18);
   outline: 2px solid #b71c1c;
@@ -249,7 +250,8 @@ div.wpforms-container .wpforms-form .wpforms-submit:focus-visible {
   transform: translateY(-1px);
 }
 
-div.wpforms-container .wpforms-form .wpforms-submit:active {
+div.wpforms-container .wpforms-form .wpforms-submit:active,
+div.wpforms-container .wpforms-form button[type="submit"]:active {
   transform: translateY(0);
 }
 
@@ -264,7 +266,8 @@ div.wpforms-container .wpforms-form .wpforms-submit:active {
     padding: 1.25rem;
   }
 
-  div.wpforms-container .wpforms-form .wpforms-submit {
+  div.wpforms-container .wpforms-form .wpforms-submit,
+  div.wpforms-container .wpforms-form button[type="submit"] {
     width: 100%;
   }
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.7.0
+ * Version:          1.8.0
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).


### PR DESCRIPTION
## Summary
- switch the WPForms name fields to a responsive grid so Voornaam/Achternaam align with the email field while keeping desktop spacing tidy
- ensure the submit button uses #e53935 in its default state and apply the styling to button[type="submit"] selectors as well
- bump the theme version to 1.8.0 and record the update in the changelog

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ca707f30bc832c9a61ad153f12441c