### PR TITLE
Adjust WPForms name field layout

### DIFF
--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -133,15 +133,16 @@ div.wpforms-container .wpforms-form .wpforms-field-hint {
 }
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  row-gap: 0.75rem;
-  column-gap: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
   margin: 0;
   padding: 0;
 }
 
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
+  flex: 1 1 0;
   min-width: 0;
   margin: 0;
   padding: 0;
@@ -149,9 +150,8 @@ div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-f
 
 @media (min-width: 48em) {
   div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 1.5rem;
-    row-gap: 0;
+    flex-direction: row;
+    gap: 1.5rem;
   }
 }
 
@@ -159,6 +159,17 @@ div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-f
 div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email input {
   width: 100%;
   max-width: 100%;
+}
+
+div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-half,
+div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-third,
+div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-fourth,
+div.wpforms-container .wpforms-form .wpforms-field .wpforms-first,
+div.wpforms-container .wpforms-form .wpforms-field .wpforms-last {
+  width: 100% !important;
+  max-width: 100% !important;
+  float: none !important;
+  clear: none !important;
 }
 
 div.wpforms-container .wpforms-form .wpforms-field-checkbox label,

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.8.0
+ * Version:          1.9.0
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).


### PR DESCRIPTION
## Summary
- switch the WPForms name field row to a flex layout with responsive stacking and consistent gaps
- override WPForms column width helper classes so name inputs stay full width of the container
- bump the child theme stylesheet version to 1.9.0

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca7aa3dbf0832ca6ad95531be7854b