### PR TITLE
Adjust WPForms styling to match desired layout

### DIFF
--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -1,284 +1,137 @@
-/* -------------------------------------------------------------------------- */
-/* Form UI refresh – WPForms (consistent layout, spacing, a11y, responsive)   */
-/* -------------------------------------------------------------------------- */
+/* 1. Google Fonts import */
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Roboto+Mono:wght@400;500;700&display=swap');
+/* 2. WPForms styling voor Divi */
 div.wpforms-container .wpforms-form {
-  background-color: var(--et_pb_light_background_color, #ffffff);
-  color: inherit;
-  font-family: inherit;
-  line-height: 1.55;
-  padding: 2rem;
-  border-radius: 0.5rem;
-  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.05);
+  background-color: #FFFFFF !important;
+  padding: 2rem !important;
+  border-radius: 0.5rem !important;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05) !important;
+  font-family: 'Roboto Mono', monospace !important;
+  color: #212121 !important;
 }
 
+/* 3. Koppen & sectietitels */
 div.wpforms-container .wpforms-form h2,
 div.wpforms-container .wpforms-form .wpforms-title {
-  color: var(--et_pb_primary_color, #e53935);
-  font-weight: 600;
-  margin-bottom: 1.5rem;
+  font-family: 'Oswald', sans-serif !important;
+  color: #E53935 !important;
+  margin-bottom: 1rem !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-field-container {
-  display: block;
-  margin: 0;
-  padding: 0;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field {
-  margin: 0;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field + .wpforms-field {
-  margin-top: 1.25rem;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field fieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-  min-width: 0;
-}
-
+/* 4. Veldlabels */
 div.wpforms-container .wpforms-form .wpforms-field-label {
-  display: inline-flex;
-  align-items: baseline;
-  column-gap: 0.25rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-  color: inherit;
+  font-family: 'Oswald', sans-serif !important;
+  color: #212121 !important;
+  margin-bottom: 0.5rem !important;
+  font-size: 1rem !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-required-label {
-  color: var(--et_pb_primary_color, #e53935);
-  font-weight: inherit;
-  line-height: 1;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field-sublabel {
-  display: block;
-  font-size: 0.875rem;
-  line-height: 1.4;
-  margin-top: 0.375rem;
-  color: rgba(33, 33, 33, 0.75);
-}
-
-div.wpforms-container .wpforms-form .wpforms-field input[type="text"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="email"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="tel"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="url"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="number"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="password"],
-div.wpforms-container .wpforms-form .wpforms-field input[type="search"],
-div.wpforms-container .wpforms-form .wpforms-field select,
-div.wpforms-container .wpforms-form .wpforms-field textarea {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(33, 33, 33, 0.2);
-  border-radius: 0.5rem;
-  background-color: var(--et_pb_light_background_color, #ffffff);
-  color: inherit;
-  font: inherit;
-  line-height: 1.5;
-  transition: border-color 160ms ease,
-    box-shadow 160ms ease,
-    outline-color 160ms ease;
-}
-
+/* 5. Input, textarea & select */
+div.wpforms-container .wpforms-form .wpforms-field input,
+div.wpforms-container .wpforms-form .wpforms-field textarea,
 div.wpforms-container .wpforms-form .wpforms-field select {
-  appearance: none;
-  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
-    linear-gradient(135deg, currentColor 50%, transparent 50%);
-  background-position: calc(100% - 1.25rem) calc(50% - 0.25rem),
-    calc(100% - 0.75rem) calc(50% - 0.25rem);
-  background-size: 0.35rem 0.35rem, 0.35rem 0.35rem;
-  background-repeat: no-repeat;
-  padding-right: 2.5rem;
+  width: 100% !important;
+  padding: 0.75rem 1rem !important;
+  border: 1px solid #F6F6F6 !important;
+  border-radius: 0.25rem !important;
+  background-color: #FFF8F7 !important;
+  font-family: 'Roboto Mono', monospace !important;
+  font-size: 0.95rem !important;
+  color: #212121 !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
 }
-
-div.wpforms-container .wpforms-form .wpforms-field textarea {
-  min-height: 9rem;
-  resize: vertical;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field input::placeholder,
-div.wpforms-container .wpforms-form .wpforms-field textarea::placeholder {
-  color: rgba(33, 33, 33, 0.6);
-  opacity: 1;
-}
-
 div.wpforms-container .wpforms-form .wpforms-field input:focus,
-div.wpforms-container .wpforms-form .wpforms-field input:focus-visible,
-div.wpforms-container .wpforms-form .wpforms-field select:focus,
-div.wpforms-container .wpforms-form .wpforms-field select:focus-visible,
 div.wpforms-container .wpforms-form .wpforms-field textarea:focus,
-div.wpforms-container .wpforms-form .wpforms-field textarea:focus-visible {
-  border-color: var(--et_pb_primary_color, #e53935);
-  outline: 2px solid var(--et_pb_primary_color, #e53935);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 3px rgba(229, 57, 53, 0.18);
-  background-color: #fff;
+div.wpforms-container .wpforms-form .wpforms-field select:focus {
+  outline: none !important;
+  border-color: #E53935 !important;
+  box-shadow: 0 0 0 3px rgba(229,57,53,0.15) !important;
+  background-color: #FFFFFF !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-field input:-webkit-autofill,
-div.wpforms-container .wpforms-form .wpforms-field textarea:-webkit-autofill {
-  box-shadow: 0 0 0 1000px var(--et_pb_light_background_color, #ffffff) inset;
-}
-
+/* 6. Beschrijvingen / helpteksten */
 div.wpforms-container .wpforms-form .wpforms-field-description,
 div.wpforms-container .wpforms-form .wpforms-field-hint {
-  font-size: 0.875rem;
-  line-height: 1.45;
-  margin-top: 0.375rem;
-  color: rgba(33, 33, 33, 0.75);
+  font-family: 'Roboto Mono', monospace !important;
+  font-size: 0.85rem !important;
+  color: #B71C1C !important;
+  margin-top: 0.25rem !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  width: 100%;
-  margin: 0;
-  padding: 0;
+/* 7. Submit-knop */
+div.wpforms-container .wpforms-form .wpforms-submit {
+  display: inline-block !important;
+  padding: 0.75rem 2rem !important;
+  background-color: #E53935 !important;
+  color: #FFFFFF !important;
+  font-family: 'Oswald', sans-serif !important;
+  font-size: 1.05rem !important;
+  text-transform: uppercase !important;
+  border: none !important;
+  border-radius: 0.25rem !important;
+  cursor: pointer !important;
+  transition: background-color 0.2s ease !important;
+}
+div.wpforms-container .wpforms-form .wpforms-submit:hover,
+div.wpforms-container .wpforms-form .wpforms-submit:focus {
+  background-color: #B71C1C !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row .wpforms-field-row-block {
-  flex: 1 1 0;
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-}
-
-@media (min-width: 48em) {
-  div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row {
-    flex-direction: row;
-    gap: 1.5rem;
-  }
-}
-
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-name .wpforms-field-row input,
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-field-email input {
-  width: 100%;
-  max-width: 100%;
-}
-
-div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-half,
-div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-third,
-div.wpforms-container .wpforms-form .wpforms-field .wpforms-one-fourth,
-div.wpforms-container .wpforms-form .wpforms-field .wpforms-first,
-div.wpforms-container .wpforms-form .wpforms-field .wpforms-last {
-  width: 100% !important;
-  max-width: 100% !important;
-  float: none !important;
-  clear: none !important;
-}
-
+/* 8. Checkboxen & radio buttons */
 div.wpforms-container .wpforms-form .wpforms-field-checkbox label,
 div.wpforms-container .wpforms-form .wpforms-field-radio label {
-  display: inline-flex;
-  align-items: center;
-  font-weight: 500;
-  margin-bottom: 0.375rem;
+  font-family: 'Roboto Mono', monospace !important;
+  font-size: 0.95rem !important;
+  color: #212121 !important;
+}
+div.wpforms-container .wpforms-form .wpforms-field-checkbox input[type="checkbox"],
+div.wpforms-container .wpforms-form .wpforms-field-radio input[type="radio"] {
+  accent-color: #E53935 !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-field-checkbox label input[type="checkbox"],
-div.wpforms-container .wpforms-form .wpforms-field-radio label input[type="radio"] {
-  margin-right: 0.5rem;
+/* 9. Achtergrondaccenten & blokken */
+div.wpforms-container .wpforms-form .wpforms-section {
+  background-color: #FFF0F0 !important;
+  padding: 1.5rem !important;
+  border-radius: 0.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+div.wpforms-container .wpforms-form .wpforms-page {
+  background-color: #FFEAEA !important;
+  padding: 1rem !important;
+  border-radius: 0.5rem !important;
 }
 
+/* 10. Error & success berichten */
 div.wpforms-container .wpforms-form .wpforms-error,
-div.wpforms-container .wpforms-form .wpforms-error-after-field,
-div.wpforms-container .wpforms-form label.wpforms-error {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--et_pb_accent_color, #b71c1c);
-  font-size: 0.875rem;
-  line-height: 1.45;
+div.wpforms-container .wpforms-form .wpforms-error-after-field {
+  color: #B71C1C !important;
+  font-family: 'Roboto Mono', monospace !important;
+  font-size: 0.9rem !important;
 }
-
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-has-error input,
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-has-error select,
-div.wpforms-container .wpforms-form .wpforms-field.wpforms-has-error textarea,
-div.wpforms-container .wpforms-form .wpforms-field input.wpforms-error,
-div.wpforms-container .wpforms-form .wpforms-field textarea.wpforms-error {
-  border-color: var(--et_pb_accent_color, #b71c1c);
-  box-shadow: 0 0 0 3px rgba(183, 28, 28, 0.15);
-}
-
 div.wpforms-container .wpforms-form .wpforms-confirmation-container {
-  border: 1px solid var(--et_pb_primary_color, #e53935);
-  background-color: rgba(229, 57, 53, 0.06);
-  border-radius: 0.5rem;
-  padding: 1rem 1.25rem;
-  color: inherit;
-  margin-top: 1.25rem;
+  border: 1px solid #E53935 !important;
+  background-color: #FFE0B2 !important;
+  padding: 1rem !important;
+  border-radius: 0.25rem !important;
+  font-family: 'Oswald', sans-serif !important;
+  color: #212121 !important;
+  margin-top: 1rem !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-submit-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  margin-top: 1.25rem;
+/* 11. Iconen (via :before) */
+div.wpforms-container .wpforms-form .wpforms-icon:before {
+  color: #E53935 !important;
+  font-size: 1.2rem !important;
 }
 
-div.wpforms-container .wpforms-form .wpforms-submit-container > * {
-  margin: 0 1rem 1rem 0;
-}
-
-div.wpforms-container .wpforms-form .wpforms-submit,
-div.wpforms-container .wpforms-form button[type="submit"] {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.875rem 2.5rem;
-  border: 0;
-  border-radius: 0.5rem;
-  background-color: #e53935;
-  color: #ffffff;
-  font: inherit;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  transition: background-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease;
-  cursor: pointer;
-}
-
-div.wpforms-container .wpforms-form .wpforms-submit > *:not(:last-child) {
-  margin-right: 0.5rem;
-}
-
-div.wpforms-container .wpforms-form .wpforms-submit:hover,
-div.wpforms-container .wpforms-form .wpforms-submit:focus,
-div.wpforms-container .wpforms-form .wpforms-submit:focus-visible,
-div.wpforms-container .wpforms-form button[type="submit"]:hover,
-div.wpforms-container .wpforms-form button[type="submit"]:focus,
-div.wpforms-container .wpforms-form button[type="submit"]:focus-visible {
-  background-color: #b71c1c;
-  box-shadow: 0 0 0 3px rgba(183, 28, 28, 0.18);
-  outline: 2px solid #b71c1c;
-  outline-offset: 2px;
-  transform: translateY(-1px);
-}
-
-div.wpforms-container .wpforms-form .wpforms-submit:active,
-div.wpforms-container .wpforms-form button[type="submit"]:active {
-  transform: translateY(0);
-}
-
-@media (min-width: 64em) {
+/* 12. Responsive tweaks */
+@media (max-width: 768px) {
   div.wpforms-container .wpforms-form {
-    padding: 2.5rem;
+    padding: 1rem !important;
   }
-}
-
-@media (max-width: 47.99em) {
-  div.wpforms-container .wpforms-form {
-    padding: 1.25rem;
-  }
-
-  div.wpforms-container .wpforms-form .wpforms-submit,
-  div.wpforms-container .wpforms-form button[type="submit"] {
-    width: 100%;
+  div.wpforms-container .wpforms-form .wpforms-submit {
+    width: 100% !important;
+    text-align: center !important;
   }
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          1.9.0
+ * Version:          2.0.0
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).


### PR DESCRIPTION
## Summary
- replace the WPForms stylesheet with the provided styling so name fields align as expected while leaving MailerLite rules untouched
- ensure only the desired form sizing rules remain applied to WPForms inputs and buttons
- bump the child theme version to 2.0.0 after updating the styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb016d9810832cbf107a23213f120b