### PR TITLE
Replace WordPress logos with custom icon

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,19 @@
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
+    width: 32px;
+    height: 32px;
+}
+
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    color: transparent;
+}
+
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
+    padding-left: 0;
+}

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,8 @@
 
 add_action( 'wp_enqueue_scripts', 'rikkermediahub_divi_child_enqueue_styles' );
 add_action( 'wp_enqueue_scripts', 'rikkermediahub_divi_child_enqueue_form_styles', 20 );
+add_action( 'login_enqueue_scripts', 'rikkermediahub_divi_child_enqueue_login_styles' );
+add_action( 'admin_enqueue_scripts', 'rikkermediahub_divi_child_enqueue_admin_styles' );
 
 /**
  * Enqueue parent and child theme stylesheets.
@@ -43,6 +45,50 @@ function rikkermediahub_divi_child_enqueue_form_styles(): void {
         $dependencies,
         wp_get_theme()->get( 'Version' )
     );
+}
+
+/**
+ * Enqueue login screen stylesheet and replace the login logo.
+ */
+function rikkermediahub_divi_child_enqueue_login_styles(): void {
+    $handle = 'rikkermediahub-divi-login';
+
+    wp_enqueue_style(
+        $handle,
+        get_stylesheet_directory_uri() . '/login/login_styles.css',
+        array(),
+        wp_get_theme()->get( 'Version' )
+    );
+
+    $logo_url  = esc_url_raw( get_stylesheet_directory_uri() . '/images/custom-icon.png' );
+    $inline_css = sprintf(
+        ".login h1 a {\n    background-image: url('%1$s');\n    background-size: contain;\n    background-repeat: no-repeat;\n    width: 120px;\n    height: 120px;\n}\n.login h1 a:focus {\n    box-shadow: none;\n}",
+        $logo_url
+    );
+
+    wp_add_inline_style( $handle, $inline_css );
+}
+
+/**
+ * Enqueue admin styles to swap the WordPress logo in the toolbar.
+ */
+function rikkermediahub_divi_child_enqueue_admin_styles(): void {
+    $handle = 'rikkermediahub-divi-admin';
+
+    wp_enqueue_style(
+        $handle,
+        get_stylesheet_directory_uri() . '/assets/css/admin.css',
+        array(),
+        wp_get_theme()->get( 'Version' )
+    );
+
+    $logo_url  = esc_url_raw( get_stylesheet_directory_uri() . '/images/custom-icon.png' );
+    $inline_css = sprintf(
+        "#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {\n    background-image: url('%1$s');\n}",
+        $logo_url
+    );
+
+    wp_add_inline_style( $handle, $inline_css );
 }
 
 require_once __DIR__ . '/inc/setup.php';

--- a/login/login_styles.css
+++ b/login/login_styles.css
@@ -1,6 +1,16 @@
-#wp-submit {
-    background-color: #eb4034 !important; 
+.login h1 a {
+    display: block;
+    width: 120px;
+    height: 120px;
+    margin: 0 auto 20px;
+    background-size: contain;
+    background-repeat: no-repeat;
 }
+
+#wp-submit {
+    background-color: #eb4034 !important;
+}
+
 #wp-submit:hover {
-    background-color: #ff0000 !important; 
+    background-color: #ff0000 !important;
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:       RikkerMediaHub Divi Child
  * Theme URI:        https://rikkermediahub.com/
  * Template:         Divi
- * Version:          2.1.0
+ * Version:          2.2.0
  * Author:           RikkerMediaHub
  * Author URI:       https://rikkermediahub.com/
  * Description:      Child theme for Divi with custom styling (WPForms, MailerLite, login page, and full-width layout fixes).


### PR DESCRIPTION
## Summary
- enqueue custom admin and login styles to swap the default WordPress logos for the theme icon
- add dedicated admin toolbar styling and refine login logo layout
- bump the child theme version to 2.2.0

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68ccfe1a6940832c80262072b131e3a5